### PR TITLE
handle missing values in CSVReader

### DIFF
--- a/tafra/base.py
+++ b/tafra/base.py
@@ -1012,7 +1012,8 @@ class Tafra:
 
     @classmethod
     def read_csv(cls, csv_file: _Union[str, Path, TextIOWrapper, IO[str]], guess_rows: int = 5,
-                 dtypes: Optional[Dict[str, str]] = None, **csvkw: Dict[str, Any]
+                 missing: Optional[str] = '', dtypes: Optional[Dict[str, str]] = None,
+                 **csvkw: Dict[str, Any]
                  ) -> 'Tafra':
         """
         Read a CSV file with a header row, infer the types of each column,
@@ -1038,7 +1039,8 @@ class Tafra:
             tafra: Tafra
                 The constructed :class:`Tafra`.
         """
-        reader = CSVReader(cast(_Union[str, Path, TextIOWrapper], csv_file), guess_rows, **csvkw)
+        reader = CSVReader(cast(_Union[str, Path, TextIOWrapper], csv_file),
+                guess_rows, missing, **csvkw)
         return Tafra(reader.read(), dtypes=dtypes)
 
     @classmethod
@@ -1908,7 +1910,7 @@ class Tafra:
             f = filename
             should_close = False
 
-            f.reconfigure(newline='')  # type: ignore
+            f.reconfigure(newline='')
 
         writer = csv.writer(f, delimiter=',', quotechar='"')
         writer.writerow((column for column in self._data.keys() if column in columns))

--- a/tafra/csvreader.py
+++ b/tafra/csvreader.py
@@ -21,9 +21,8 @@ import numpy as np
 
 from enum import Enum, auto
 from io import TextIOWrapper
-from typing import Any, Callable, Dict, List, Tuple, Type, IO
-from typing import Union
-from typing import cast
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type
+from typing import IO, Union, cast
 
 # this doesn't type well in Python
 @dc.dataclass(frozen=True)
@@ -61,17 +60,19 @@ class ReaderState(Enum):
     DONE = auto()
 
 class CSVReader:
-    def __init__(self, source: Union[str, Path, TextIOWrapper], guess_rows: int = 5,
+    def __init__(self, source: Union[str, Path, TextIOWrapper],
+                 guess_rows: int = 5, missing: Optional[str] = '',
                  **csvkw: Dict[str, Any]):
         if isinstance(source, (str, Path)):
             self._stream = open(source, newline='')
             self._should_close = True
         elif isinstance(source, TextIOWrapper):
-            source.reconfigure(newline='')  # type: ignore
+            source.reconfigure(newline='')
             self._stream = source
             self._should_close = False
-        self._reader = csv.reader(self._stream, dialect='excel', **csvkw)
-        self._header = _unique_header(next(self._reader))
+        reader = csv.reader(self._stream, dialect='excel', **csvkw)
+        self._header = _unique_header(next(reader))
+        self._reader = (self._decode_missing(t) for t in reader)
         self._guess_types = {
             col: _TYPE_PRECEDENCE[0] for col in self._header
         }
@@ -80,6 +81,7 @@ class CSVReader:
         }
         self._data: Dict[str, List[Any]] = dict()
         self._guess_rows = guess_rows
+        self._missing = missing
         self._rows = 0
         self._state = ReaderState.AWAIT_GUESSABLE
 
@@ -173,10 +175,10 @@ class CSVReader:
             self._stream.close()
         self._state = ReaderState.DONE
 
-    def _promote(self, col: str, val: str) -> None:
+    def _promote(self, col: str, val: Optional[str]) -> None:
         ty_ix = _TYPE_PRECEDENCE.index(self._guess_types[col])
         try_next = _TYPE_PRECEDENCE[ty_ix + 1:]
-        stringized = list(map(str, self._data[col]))
+        stringized = self._encode_missing(self._data[col])
         stringized.append(val)
         ty, parsed = _guess_column(try_next, stringized)
         self._guess_types[col] = ty
@@ -188,6 +190,14 @@ class CSVReader:
             col: np.array(self._data[col], dtype=self._guess_types[col].dtype)
             for col in self._header
         }
+
+    def _decode_missing(self, row: List[str]) -> Sequence[Optional[str]]:
+        if self._missing is None:
+            return row
+        return [v if v != self._missing else None for v in row]
+
+    def _encode_missing(self, row: Sequence[Optional[Any]]) -> List[Optional[str]]:
+        return [str(v) if v is not None else self._missing for v in row]
 
 def _unique_header(header: List[str]) -> List[str]:
     uniq: List[str] = list()
@@ -201,7 +211,7 @@ def _unique_header(header: List[str]) -> List[str]:
     return uniq
 
 # the "real" return type is a dependent pair (t: ReadableType ** List[t.dtype])
-def _guess_column(precedence: List[ReadableType], vals: List[str]
+def _guess_column(precedence: List[ReadableType], vals: List[Optional[str]]
                   ) -> Tuple[ReadableType, List[Any]]:
     for ty in precedence:
         try:

--- a/test/test_tafra.py
+++ b/test/test_tafra.py
@@ -1143,11 +1143,11 @@ def test_csv() -> None:
     with pytest.raises(ValueError) as e:
         t = Tafra.read_csv('test/ex5.csv', guess_rows=2)
 
-    # missing column, override dtypes
+    # missing column - but numpy will automatically convert missing (None) to nan
     t = Tafra.read_csv('test/ex6.csv')
     assert t.dtypes['dp'] == 'float64'
-    assert t.dtypes['dp_prime'] == 'object'
-    assert t.dtypes['dp_prime_te'] == 'object'
+    assert t.dtypes['dp_prime'] == 'float64'
+    assert t.dtypes['dp_prime_te'] == 'float64'
     assert t.dtypes['t'] == 'float64'
     assert t.dtypes['te'] == 'float64'
     check_tafra(t)


### PR DESCRIPTION
Add missing-value handling to CSVReader. A user-specified "missing indicator" string (default `''`) may be provided; `None` disables missing-value detection. Missing values are represented as `None`; individual type parsing functions may now handle `None` however they wish.

For instance, `numpy.float64` will convert `None` to `nan`, which matches common usage. Due to the fallback logic, this means that numeric columns containing missing values may be inferred as `float64` rather than an integer type, even if all non-missing values are integral. Columns of other types with missing values will be inferred as `object` with explicit `None` elements.