### PR TITLE
feat: parameterized queries in read_sql + bump to 2.2.3

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,16 @@
 # Version History
 
+## 2.2.3
+
+* **Feature**: `read_sql` and `read_sql_chunks` accept an optional
+  ``params: Sequence[Any] | None`` argument for parameterized queries using
+  ``?`` placeholders.  Passed unchanged to ``cur.execute``.  The `Cursor`
+  protocol's ``execute`` signature is updated to match pyodbc's variadic form.
+* **Fix**: CSV fixture paths in `test_csv` now resolve relative to
+  `Path(__file__).parent` instead of a hardcoded `"test/"` prefix. This fixes
+  `FileNotFoundError` in conda-forge builds where pytest's cwd is not the
+  repo root.
+
 ## 2.2.2
 
 * **Fix**: Multi-column join composite key collision when left and right sides

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tafra"
-version = "2.2.2"
+version = "2.2.3"
 description = "Tafra: essence of a dataframe"
 readme = "README.md"
 license = "MIT"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tafra" %}
-{% set version = "2.2.2" %}
+{% set version = "2.2.3" %}
 
 
 package:

--- a/tafra/__init__.py
+++ b/tafra/__init__.py
@@ -25,3 +25,22 @@ read_sql = Tafra.read_sql
 read_sql_chunks = Tafra.read_sql_chunks
 read_csv = Tafra.read_csv
 as_tafra = Tafra.as_tafra
+
+__all__ = [
+    "Tafra",
+    "object_formatter",
+    "Union",
+    "GroupBy",
+    "Transform",
+    "IterateBy",
+    "InnerJoin",
+    "LeftJoin",
+    "CrossJoin",
+    "percentile",
+    "geomean",
+    "harmean",
+    "read_sql",
+    "read_sql_chunks",
+    "read_csv",
+    "as_tafra",
+]

--- a/tafra/base.py
+++ b/tafra/base.py
@@ -1018,7 +1018,12 @@ class Tafra:
         )
 
     @classmethod
-    def read_sql(cls, query: str, cur: Cursor) -> "Tafra":
+    def read_sql(
+        cls,
+        query: str,
+        cur: Cursor,
+        params: Sequence[Any] | None = None,
+    ) -> "Tafra":
         """
         Execute a SQL SELECT statement using a `pyodbc.Cursor` and return a Tuple
         of column names and an Iterator of records.
@@ -1026,17 +1031,24 @@ class Tafra:
         Parameters
         ----------
         query: str
-            The SQL query.
+            The SQL query, optionally containing ``?`` placeholders.
 
         cur: pyodbc.Cursor
             The `pyodbc` cursor.
+
+        params: Sequence[Any] | None
+            Optional sequence of parameter values to bind to ``?`` placeholders
+            in the query.  Passed unchanged to ``cur.execute``.
 
         Returns
         -------
         tafra: Tafra
             The constructed `Tafra`.
         """
-        cur.execute(query)
+        if params is None:
+            cur.execute(query)
+        else:
+            cur.execute(query, params)
 
         columns, dtypes = zip(*((d[0], d[1]) for d in cur.description))
 
@@ -1047,7 +1059,13 @@ class Tafra:
         return Tafra.from_records(chain([head], cur.fetchall()), columns, dtypes)
 
     @classmethod
-    def read_sql_chunks(cls, query: str, cur: Cursor, chunksize: int = 100) -> Iterator["Tafra"]:
+    def read_sql_chunks(
+        cls,
+        query: str,
+        cur: Cursor,
+        chunksize: int = 100,
+        params: Sequence[Any] | None = None,
+    ) -> Iterator["Tafra"]:
         """
         Execute a SQL SELECT statement using a `pyodbc.Cursor` and return a Tuple
         of column names and an Iterator of records.
@@ -1055,17 +1073,27 @@ class Tafra:
         Parameters
         ----------
         query: str
-            The SQL query.
+            The SQL query, optionally containing ``?`` placeholders.
 
         cur: pyodbc.Cursor
             The `pyodbc` cursor.
+
+        chunksize: int
+            Number of rows to yield per chunk.
+
+        params: Sequence[Any] | None
+            Optional sequence of parameter values to bind to ``?`` placeholders
+            in the query.  Passed unchanged to ``cur.execute``.
 
         Returns
         -------
         tafra: Tafra
             The constructed `Tafra`.
         """
-        cur.execute(query)
+        if params is None:
+            cur.execute(query)
+        else:
+            cur.execute(query, params)
 
         columns, dtypes = zip(*((d[0], d[1]) for d in cur.description))
 

--- a/tafra/base.py
+++ b/tafra/base.py
@@ -1025,8 +1025,8 @@ class Tafra:
         params: Sequence[Any] | None = None,
     ) -> "Tafra":
         """
-        Execute a SQL SELECT statement using a `pyodbc.Cursor` and return a Tuple
-        of column names and an Iterator of records.
+        Execute a SQL SELECT statement using a `pyodbc.Cursor` and return a
+        `Tafra` of the result set.
 
         Parameters
         ----------
@@ -1067,8 +1067,8 @@ class Tafra:
         params: Sequence[Any] | None = None,
     ) -> Iterator["Tafra"]:
         """
-        Execute a SQL SELECT statement using a `pyodbc.Cursor` and return a Tuple
-        of column names and an Iterator of records.
+        Execute a SQL SELECT statement using a `pyodbc.Cursor` and yield
+        chunks of the result set as `Tafra` instances.
 
         Parameters
         ----------
@@ -1085,10 +1085,10 @@ class Tafra:
             Optional sequence of parameter values to bind to ``?`` placeholders
             in the query.  Passed unchanged to ``cur.execute``.
 
-        Returns
-        -------
+        Yields
+        ------
         tafra: Tafra
-            The constructed `Tafra`.
+            A `Tafra` containing up to `chunksize` rows of the result set.
         """
         if params is None:
             cur.execute(query)

--- a/tafra/protocol.py
+++ b/tafra/protocol.py
@@ -58,7 +58,7 @@ class Cursor(Protocol):
     def __next__(self) -> tuple[Any, ...]:
         raise NotImplementedError
 
-    def execute(self, sql: str) -> None:
+    def execute(self, sql: str, *params: Any) -> None:
         raise NotImplementedError
 
     def fetchone(self) -> tuple[Any, ...] | None:

--- a/tafra/protocol.py
+++ b/tafra/protocol.py
@@ -50,7 +50,7 @@ class Cursor(Protocol):
     A fake class to satisfy typing of a ``pyodbc.Cursor`` without a dependency.
     """
 
-    description: tuple[tuple[str, type[Any], int | None, int, int, int, bool]]
+    description: tuple[tuple[str, type[Any], int | None, int, int, int, bool], ...]
 
     def __iter__(self) -> Iterator[tuple[Any, ...]]:
         raise NotImplementedError

--- a/test/test_tafra.py
+++ b/test/test_tafra.py
@@ -58,7 +58,12 @@ class Cursor:
         self.idx += 1
         return item
 
-    def execute(self, sql: str) -> None: ...
+    last_sql: str | None = None
+    last_params: tuple[Any, ...] | None = None
+
+    def execute(self, sql: str, *params: Any) -> None:
+        self.last_sql = sql
+        self.last_params = params
 
     def fetchone(self) -> tuple[Any, ...] | None:
         try:
@@ -438,6 +443,50 @@ class TestSQL:
             cur,
         ):
             check_tafra(t)
+
+    def test_read_sql_with_params(self) -> None:
+        """read_sql passes params to cur.execute when provided."""
+        cur = Cursor()
+        t = Tafra.read_sql(  # type: ignore
+            "SELECT * FROM [Table] WHERE [Fruit]=? AND [Amount]>?",
+            cur,
+            params=["Apples", 3],
+        )
+        check_tafra(t)
+        assert cur.last_params == (["Apples", 3],)
+
+        # No params → execute called without extra args
+        cur = Cursor()
+        Tafra.read_sql("SELECT * FROM [Table]", cur)  # type: ignore
+        assert cur.last_params == ()
+
+        # Tuple params also accepted
+        cur = Cursor()
+        Tafra.read_sql(  # type: ignore
+            "SELECT * FROM [Table] WHERE [Fruit]=?",
+            cur,
+            params=("Apples",),
+        )
+        assert cur.last_params == (("Apples",),)
+
+    def test_read_sql_chunks_with_params(self) -> None:
+        """read_sql_chunks passes params to cur.execute when provided."""
+        cur = Cursor()
+        for t in Tafra.read_sql_chunks(  # type: ignore
+            "SELECT * FROM [Table] WHERE [Fruit]=?",
+            cur,
+            params=["Apples"],
+        ):
+            check_tafra(t)
+        assert cur.last_params == (["Apples"],)
+
+        cur = Cursor()
+        for t in Tafra.read_sql_chunks(  # type: ignore
+            "SELECT * FROM [Table]",
+            cur,
+        ):
+            check_tafra(t)
+        assert cur.last_params == ()
 
 
 class TestDestructors:

--- a/test/test_tafra.py
+++ b/test/test_tafra.py
@@ -447,17 +447,16 @@ class TestSQL:
     def test_read_sql_with_params(self) -> None:
         """read_sql passes params to cur.execute when provided."""
         cur = Cursor()
-        t = Tafra.read_sql(  # type: ignore
-            "SELECT * FROM [Table] WHERE [Fruit]=? AND [Amount]>?",
-            cur,
-            params=["Apples", 3],
-        )
+        query = "SELECT * FROM [Table] WHERE [Fruit]=? AND [Amount]>?"
+        t = Tafra.read_sql(query, cur, params=["Apples", 3])  # type: ignore
         check_tafra(t)
+        assert cur.last_sql == query
         assert cur.last_params == (["Apples", 3],)
 
         # No params → execute called without extra args
         cur = Cursor()
         Tafra.read_sql("SELECT * FROM [Table]", cur)  # type: ignore
+        assert cur.last_sql == "SELECT * FROM [Table]"
         assert cur.last_params == ()
 
         # Tuple params also accepted
@@ -472,12 +471,10 @@ class TestSQL:
     def test_read_sql_chunks_with_params(self) -> None:
         """read_sql_chunks passes params to cur.execute when provided."""
         cur = Cursor()
-        for t in Tafra.read_sql_chunks(  # type: ignore
-            "SELECT * FROM [Table] WHERE [Fruit]=?",
-            cur,
-            params=["Apples"],
-        ):
+        query = "SELECT * FROM [Table] WHERE [Fruit]=?"
+        for t in Tafra.read_sql_chunks(query, cur, params=["Apples"]):  # type: ignore
             check_tafra(t)
+        assert cur.last_sql == query
         assert cur.last_params == (["Apples"],)
 
         cur = Cursor()
@@ -486,6 +483,7 @@ class TestSQL:
             cur,
         ):
             check_tafra(t)
+        assert cur.last_sql == "SELECT * FROM [Table]"
         assert cur.last_params == ()
 
 


### PR DESCRIPTION
## Summary

- **Feature**: `read_sql` and `read_sql_chunks` accept an optional `params: Sequence[Any] | None` argument for parameterized queries using `?` placeholders. Passed unchanged to `cur.execute`, so pyodbc's internal sequence-unpacking handles binding.
- **Protocol**: `Cursor.execute` signature updated to `execute(self, sql: str, *params: Any)` to match pyodbc's real variadic form.
- **Docstrings**: Fixed pre-existing stale summaries on `read_sql`/`read_sql_chunks` (they claimed to return a "Tuple of column names and an Iterator of records").
- **Tests**: New `test_read_sql_with_params` and `test_read_sql_chunks_with_params` verify parameter propagation in both methods. Mock `Cursor` now records `last_sql`/`last_params`.
- **Package**: Added `__all__` to `tafra/__init__.py` to make public API explicit.
- **Version**: Bumped to 2.2.3 with changelog entry.

## API

```python
# Single parameter
Tafra.read_sql("SELECT * FROM t WHERE x = ?", cur, params=[42])

# Multiple parameters — IN clause
Tafra.read_sql("SELECT * FROM t WHERE basin IN (?, ?)", cur, params=["DELAWARE", "MIDLAND"])

# No params (unchanged behavior)
Tafra.read_sql("SELECT * FROM t", cur)
```

## Test plan

- [x] `pytest` — 201 tests pass (199 existing + 2 new)
- [x] `ruff check tafra` — clean
- [x] `mypy tafra` — clean
- [x] Verified end-to-end against Xcalibur: `SELECT TOP 10 * FROM [Xcalibur].[dbo].[WellHeader] WHERE [Basin] = ?` with `params=['DELAWARE']` → 10 rows, all Basin='DELAWARE'
- [x] Verified IN-clause: `WHERE [Basin] IN (?, ?)` with `['DELAWARE', 'MIDLAND']` → rows returned with both basins

🤖 Generated with [Claude Code](https://claude.com/claude-code)