### PR TITLE
fix: restore MANIFEST.in for sdist test fixtures (v2.2.4)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include LICENSE
+include README.md
+include pyproject.toml
+recursive-include tafra *.py *.c *.h py.typed
+recursive-include test *.py *.csv
+exclude CLAUDE.md

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Version History
 
+## 2.2.4
+
+* **Fix**: Restore `MANIFEST.in` so test CSV fixtures (`test/ex*.csv`) are
+  included in the PyPI sdist.  Removing `MANIFEST.in` in 2.2.1 silently
+  broke the conda-forge test stage for 2.2.1, 2.2.2, and 2.2.3 because
+  `source_files: test` could not find the CSVs.  No code changes.
+
 ## 2.2.3
 
 * **Feature**: `read_sql` and `read_sql_chunks` accept an optional

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tafra"
-version = "2.2.3"
+version = "2.2.4"
 description = "Tafra: essence of a dataframe"
 readme = "README.md"
 license = "MIT"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tafra" %}
-{% set version = "2.2.3" %}
+{% set version = "2.2.4" %}
 
 
 package:


### PR DESCRIPTION
## Summary

v2.2.1 removed \`MANIFEST.in\` with the claim it was "unnecessary with setuptools>=64 + pyproject.toml". That was wrong — setuptools still requires \`MANIFEST.in\` (or equivalent) to include non-Python files in the sdist.

The test CSV fixtures (\`test/ex1.csv\` through \`test/ex6.csv\`) have been missing from every PyPI sdist since v2.2.1. This silently broke the conda-forge test stage for three releases (v2.2.1, v2.2.2, v2.2.3) — all three feedstock PRs failed with \`FileNotFoundError: test/ex1.csv\`.

This PR restores \`MANIFEST.in\` with explicit inclusion of the test CSVs (and exclusion of \`CLAUDE.md\`, which setuptools was silently including). Bumps to v2.2.4 since v2.2.3 is already on PyPI (immutable).

## Verification

\`\`\`bash
$ python -m build --sdist
$ tar -tzf dist/tafra-2.2.4.tar.gz | grep test/ex
tafra-2.2.4/test/ex1.csv
tafra-2.2.4/test/ex2.csv
tafra-2.2.4/test/ex3.csv
tafra-2.2.4/test/ex4.csv
tafra-2.2.4/test/ex5.csv
tafra-2.2.4/test/ex6.csv
\`\`\`

## Test plan

- [x] \`python -m build --sdist\` produces a tarball with all test CSVs
- [x] CLAUDE.md excluded from sdist
- [x] No code changes — no risk to library functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)